### PR TITLE
Make installer easier, adt-user now actually uses the conda env

### DIFF
--- a/EZ_Facehugger.py
+++ b/EZ_Facehugger.py
@@ -35,7 +35,7 @@ local_file_paths = [
     "model_index.json"
 ]
 
-sd_root = "StableDiffusion/"
+sd_root = "models/StableDiffusion/"
 
 for file_path in local_file_paths:
     file_url = f"{base_download_url}/{file_path}"

--- a/adt-user.bat
+++ b/adt-user.bat
@@ -1,1 +1,5 @@
+@echo off
+call conda activate adt
+
+@echo on
 python ez-adt_v0.py

--- a/environment.yaml
+++ b/environment.yaml
@@ -24,3 +24,6 @@ dependencies:
     - scipy
     - compel
     - xformers==0.0.16
+    - google
+    - protobuf
+    - tensorboardX

--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,23 @@
+@echo off
+call conda activate adt
+
+REM Download runwayml/StableDiffusion
+echo Downloading runwayml/StableDiffusion...
+python EZ_Facehugger.py
+
+REM Download the motion modules
+echo Downloading motion modules...
+if not exist "models/Motion_Module/mm_sd_v14.ckpt" (
+    gdown 1RqkQuGPaCO5sGZ6V6KZ-jUWmsRu48Kdq -O models/Motion_Module/mm_sd_v14.ckpt
+) else (
+	echo mm_sd_v14.ckpt already exists, skipping download
+)
+
+if not exist "models/Motion_Module/mm_sd_v15.ckpt" (
+    gdown 1ql0g_Ys4UCz2RnokYlBjyOYPbttbIpbu -O models/Motion_Module/mm_sd_v15.ckpt
+) else (
+	echo mm_sd_v15.ckpt already exists, skipping download
+)
+
+echo Install finished!
+pause

--- a/models/download_SD1.5_prereq.bat
+++ b/models/download_SD1.5_prereq.bat
@@ -1,3 +1,0 @@
-pip install requests
-pip install os
-python EZ_Facehugger.py


### PR DESCRIPTION
installer.bat to do all of the junk
adt-user now does conda environment

Had annoying permission issues setting up conda install environmet but it's something like

```
@echo off
setlocal enabledelayedexpansion

REM Check if the conda environment 'ADT' exists
conda info --envs | findstr "^ADT " > nul

REM If 'ADT' environment is not found, create it
if errorlevel 1 (
    conda env create -f environment.yaml
) else (
    echo The 'ADT' environment already exists.
    set /p userChoice=Do you want to reinstall it? [y/n]: 
    if /i "!userChoice:~0,1!"=="y" (
		echo Reinstalling 'ADT' environment...
        conda env remove --name adt
        conda env create -f environment.yaml
		if errorlevel 1 echo "Failed to create environment"
    ) else (
        echo Skipping installation.
    )
)
```

But get permission issue sometimes. Will put in later so that it installs conda environment too but manual isn't a big deal I guess